### PR TITLE
Make compatible with latest GHC 8 and Stackage nightly

### DIFF
--- a/cereal-text.cabal
+++ b/cereal-text.cabal
@@ -31,6 +31,8 @@ library
   exposed-modules: Data.Serialize.Text
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >= 4.0 && <4.9, cereal >= 0.2, text >= 0.10
+  build-depends:       base >= 4.0, 
+                       cereal >= 0.2, 
+                       text >= 0.10
   -- hs-source-dirs:      
   default-language:    Haskell2010


### PR DESCRIPTION
Currently "chatter" library cannot be compiled against latest GHC 8 and latest Stackage Nightly because of this base constraint. If it is removed "cereal-text" will be compatible with GHC 8, too.
